### PR TITLE
fix configure generation errors

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -139,7 +139,7 @@
 //
 // Make information about the build available.
 //
-#define CC_DATE     "${CFG_DATE:-"$(date '+%Y-%m-%d %H:%M')"}"
+#define CC_DATE     "${CFG_DATE:-$(date '+%Y-%m-%d %H:%M')}"
 #define CC_BRANCH   "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo n/a)"
 #define CC_COMMIT   "$(git rev-parse HEAD 2>/dev/null || echo n/a)"
 #define CFG_VERSION "$CFG_VERSION"


### PR DESCRIPTION
When cloning dfm for the first time and running the configure script, where the Makefile is generated by bin/dpp and the .gitignore generated afterwards, a finish-to-start dependency error occurs where bin/dpp depends on .gitignore before it was created.

Removes the extraneous quote that breaks building with LLVM.