### PR TITLE
bin/u8: fix shell implementations byte splitting

### DIFF
--- a/bin/u8
+++ b/bin/u8
@@ -23,8 +23,10 @@
 # SOFTWARE.
 #
 
-LC_ALL=C
-a=$1 b=${a#?} c=${b#?} d=${c#?}
+export LC_ALL=C
+a=$1; b=${a#?}; c=${b#?}; d=${c#?}
+unset LC_ALL
+
 a=${a%"$b"} b=${b%"$c"} c=${c%"$d"} d=${d%"${1#????}"}
 export $(printf 'a=%d b=%d c=%d d=%d' "'$a" "'$b" "'$c" "'$d")
 printf '0x%08X\n' "$((a < 128 ? a : a < 224 ?


### PR DESCRIPTION
It seems that certain shell implementations, such as FreeBSD sh, ignore LC_ALL unless it is exported to the environment, exporting it during byte splitting allows the character to be split correctly.

Additionally, implementations do not allow variables that reference the a previously declared variable in the same expression without making it a separate expression (eg. : foo=bar bar=$foo) yields bar to be empty on FreeBSD sh.